### PR TITLE
Fallback to other globals on global-this failure

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -256,6 +256,17 @@ export const InternalUtils = {
 		}
 		/* eslint-enable */
 
+		if (typeof _globalThis === 'undefined') {
+			// Still unable to determine the global-this, fall back to a naive method:
+			if (typeof self !== 'undefined') {
+				_globalThis = self;
+			} else if (typeof window !== 'undefined') {
+				_globalThis = window;
+			} else if (typeof global !== 'undefined') {
+				_globalThis = global;
+			}
+		}
+
 		Object.defineProperty(this, 'globalThis', {
 			enumerable: true,
 			value: _globalThis

--- a/src/utils.js
+++ b/src/utils.js
@@ -240,7 +240,7 @@ export const InternalUtils = {
 	get globalThis() {
 		let _globalThis;
 
-		/* eslint-disable no-extend-native, no-undef */
+		/* eslint-disable no-extend-native, no-restricted-globals, no-undef */
 		if (typeof globalThis === 'object') {
 			_globalThis = globalThis;
 		} else {
@@ -254,10 +254,9 @@ export const InternalUtils = {
 				delete Object.prototype.__magicalGlobalThis__;
 			}
 		}
-		/* eslint-enable */
 
 		if (typeof _globalThis === 'undefined') {
-			// Still unable to determine the global-this, fall back to a naive method:
+			// Still unable to determine "globalThis", fall back to a naive method:
 			if (typeof self !== 'undefined') {
 				_globalThis = self;
 			} else if (typeof window !== 'undefined') {
@@ -266,6 +265,7 @@ export const InternalUtils = {
 				_globalThis = global;
 			}
 		}
+		/* eslint-enable */
 
 		Object.defineProperty(this, 'globalThis', {
 			enumerable: true,


### PR DESCRIPTION
Fixes #6 

This PR uses a naive fallback for `globalThis` in the case that the `this` value within the magic scope is `undefined`. However rare, this still poses issues for downstream libraries that operate on platforms like React Native (& iOS 11, for some reason).

The fallback uses `self`, `window` and then `global`, respectively, when trying to determine another context to use instead.