### PR TITLE
Do not generate every token in the specified time-window

### DIFF
--- a/src/hotp.js
+++ b/src/hotp.js
@@ -171,7 +171,7 @@ class HOTP {
     };
 
     check(counter);
-    for (let i = 0; i <= window && delta === null; ++i) {
+    for (let i = 1; i <= window && delta === null; ++i) {
       check(counter - i);
       if (delta !== null) break;
       check(counter + i);
@@ -208,12 +208,11 @@ class HOTP {
     const e = encodeURIComponent;
     return (
       "otpauth://hotp/" +
-      `${
-        this.issuer.length > 0
-          ? this.issuerInLabel
-            ? `${e(this.issuer)}:${e(this.label)}?issuer=${e(this.issuer)}&`
-            : `${e(this.label)}?issuer=${e(this.issuer)}&`
-          : `${e(this.label)}?`
+      `${this.issuer.length > 0
+        ? this.issuerInLabel
+          ? `${e(this.issuer)}:${e(this.label)}?issuer=${e(this.issuer)}&`
+          : `${e(this.label)}?issuer=${e(this.issuer)}&`
+        : `${e(this.label)}?`
       }` +
       `secret=${e(this.secret.base32)}&` +
       `algorithm=${e(this.algorithm)}&` +

--- a/src/hotp.js
+++ b/src/hotp.js
@@ -208,11 +208,12 @@ class HOTP {
     const e = encodeURIComponent;
     return (
       "otpauth://hotp/" +
-      `${this.issuer.length > 0
-        ? this.issuerInLabel
-          ? `${e(this.issuer)}:${e(this.label)}?issuer=${e(this.issuer)}&`
-          : `${e(this.label)}?issuer=${e(this.issuer)}&`
-        : `${e(this.label)}?`
+      `${
+        this.issuer.length > 0
+          ? this.issuerInLabel
+            ? `${e(this.issuer)}:${e(this.label)}?issuer=${e(this.issuer)}&`
+            : `${e(this.label)}?issuer=${e(this.issuer)}&`
+          : `${e(this.label)}?`
       }` +
       `secret=${e(this.secret.base32)}&` +
       `algorithm=${e(this.algorithm)}&` +

--- a/src/hotp.js
+++ b/src/hotp.js
@@ -158,17 +158,24 @@ class HOTP {
 
     let delta = null;
 
-    for (let i = counter - window; i <= counter + window; ++i) {
+    const check = (/** @type {number} */ i) => {
       const generatedToken = HOTP.generate({
         secret,
         algorithm,
         digits,
         counter: i,
       });
-
       if (timingSafeEqual(token, generatedToken)) {
         delta = i - counter;
       }
+    };
+
+    check(counter);
+    for (let i = 0; i <= window && delta === null; ++i) {
+      check(counter - i);
+      if (delta !== null) break;
+      check(counter + i);
+      if (delta !== null) break;
     }
 
     return delta;


### PR DESCRIPTION
This will immidiatly return when a correct token is found. It will also start with comparing the token against the one for the current time, then 1 token before the current time, 1 after, 2 before the current time etc.. until the complete window is compared or  a valid  token is found. 

This should improve performance, because most of the time the current token or the previous token is submitted.

This should fix #487 