### PR TITLE
Fix shift in uintEncode

### DIFF
--- a/src/internal/encoding/uint.js
+++ b/src/internal/encoding/uint.js
@@ -27,10 +27,8 @@ const uintEncode = (arr) => {
   let num = 0;
 
   for (let i = 0; i < arr.length; i++) {
-    if (arr[i] !== 0) {
-      num *= 256;
-      num += arr[i];
-    }
+    num *= 256;
+    num += arr[i];
   }
 
   return num;


### PR DESCRIPTION
This commit fixes the error which causes the result to skip null bytes. Example: `uintEncode(uintDecode(0x12003400)).toString(16)` returns `'1234'`. I think this error does not lead to a vulnerability.

It also removes the conditional which is more redundant than `+= 0`.
