### PR TITLE
extract TOTP.counter({ period, timestamp }) as static function

### DIFF
--- a/src/totp.js
+++ b/src/totp.js
@@ -93,10 +93,23 @@ class TOTP {
    * @param {Object} [config] Configuration options.
    * @param {number} [config.period=30] Token time-step duration.
    * @param {number} [config.timestamp=Date.now] Timestamp value in milliseconds.
-   * @returns {number} counter.
+   * @returns {number} Counter.
    */
   static counter({ period = TOTP.defaults.period, timestamp = Date.now() } = {}) {
     return Math.floor(timestamp / 1000 / period);
+  }
+
+  /**
+   * Calculates the counter. i.e. the number of periods since timestamp 0.
+   * @param {Object} [config] Configuration options.
+   * @param {number} [config.timestamp=Date.now] Timestamp value in milliseconds.
+   * @returns {number} Counter.
+   */
+  counter({ timestamp = Date.now() } = {}) {
+    return TOTP.counter({
+      period: this.period,
+      timestamp,
+    });
   }
 
   /**

--- a/src/totp.js
+++ b/src/totp.js
@@ -88,15 +88,14 @@ class TOTP {
     this.period = period;
   }
 
-
   /**
    * Calculates the counter. i.e. the number of periods since timestamp 0.
-   * @param {Object} config Configuration options.
+   * @param {Object} [config] Configuration options.
    * @param {number} [config.period=30] Token time-step duration.
    * @param {number} [config.timestamp=Date.now] Timestamp value in milliseconds.
    * @returns {number} counter.
    */
-  static counter({ period = TOTP.defaults.period, timestamp = Date.now() }) {
+  static counter({ period = TOTP.defaults.period, timestamp = Date.now() } = {}) {
     return Math.floor(timestamp / 1000 / period);
   }
 

--- a/src/totp.js
+++ b/src/totp.js
@@ -94,7 +94,7 @@ class TOTP {
    * @param {Object} config Configuration options.
    * @param {number} [config.period=30] Token time-step duration.
    * @param {number} [config.timestamp=Date.now] Timestamp value in milliseconds.
-   * @returns {string} counter.
+   * @returns {number} counter.
    */
   static counter({ period = TOTP.defaults.period, timestamp = Date.now() }) {
     return Math.floor(timestamp / 1000 / period);

--- a/src/totp.js
+++ b/src/totp.js
@@ -88,6 +88,18 @@ class TOTP {
     this.period = period;
   }
 
+
+  /**
+   * Calculates the counter. i.e. the number of periods since timestamp 0.
+   * @param {Object} config Configuration options.
+   * @param {number} [config.period=30] Token time-step duration.
+   * @param {number} [config.timestamp=Date.now] Timestamp value in milliseconds.
+   * @returns {string} counter.
+   */
+  static counter({ period = TOTP.defaults.period, timestamp = Date.now() }) {
+    return Math.floor(timestamp / 1000 / period);
+  }
+
   /**
    * Generates a TOTP token.
    * @param {Object} config Configuration options.
@@ -103,7 +115,7 @@ class TOTP {
       secret,
       algorithm,
       digits,
-      counter: Math.floor(timestamp / 1000 / period),
+      counter: TOTP.counter({ period, timestamp }),
     });
   }
 
@@ -141,7 +153,7 @@ class TOTP {
       secret,
       algorithm,
       digits,
-      counter: Math.floor(timestamp / 1000 / period),
+      counter: TOTP.counter({ period, timestamp }),
       window,
     });
   }

--- a/src/totp.js
+++ b/src/totp.js
@@ -113,6 +113,30 @@ class TOTP {
   }
 
   /**
+   * Calculates the remaining time in milliseconds until the next token is generated.
+   * @param {Object} [config] Configuration options.
+   * @param {number} [config.period=30] Token time-step duration.
+   * @param {number} [config.timestamp=Date.now] Timestamp value in milliseconds.
+   * @returns {number} counter.
+   */
+  static remaining({ period = TOTP.defaults.period, timestamp = Date.now() } = {}) {
+    return period * 1000 - (timestamp % (period * 1000));
+  }
+
+  /**
+   * Calculates the remaining time in milliseconds until the next token is generated.
+   * @param {Object} [config] Configuration options.
+   * @param {number} [config.timestamp=Date.now] Timestamp value in milliseconds.
+   * @returns {number} counter.
+   */
+  remaining({ timestamp = Date.now() } = {}) {
+    return TOTP.remaining({
+      period: this.period,
+      timestamp,
+    });
+  }
+
+  /**
    * Generates a TOTP token.
    * @param {Object} config Configuration options.
    * @param {Secret} config.secret Secret key.

--- a/test/test.mjs
+++ b/test/test.mjs
@@ -1353,8 +1353,8 @@ describe("TOTP", () => {
     const totp = new OTPAuth.TOTP();
     const timestamp = Date.now();
 
-    assertEquals(totp.remaining({ timestamp }), 30e3 - (timestamp % (30e3)));
-    assertEquals(OTPAuth.TOTP.remaining({ timestamp, period: 60 }), 60e3 - (timestamp % (60e3)));
+    assertEquals(totp.remaining({ timestamp }), 30e3 - (timestamp % 30e3));
+    assertEquals(OTPAuth.TOTP.remaining({ timestamp, period: 60 }), 60e3 - (timestamp % 60e3));
   });
 
   cases.forEach((input, index) => {

--- a/test/test.mjs
+++ b/test/test.mjs
@@ -1341,6 +1341,22 @@ describe("TOTP", () => {
     assertEquals(totp.validate({ token: totp.generate() }), 0);
   });
 
+  it("counter", () => {
+    const totp = new OTPAuth.TOTP();
+    const timestamp = Date.now();
+
+    assertEquals(totp.counter({ timestamp }), Math.floor(timestamp / 30e3));
+    assertEquals(OTPAuth.TOTP.counter({ timestamp, period: 60 }), Math.floor(timestamp / 60e3));
+  });
+
+  it("remaining", () => {
+    const totp = new OTPAuth.TOTP();
+    const timestamp = Date.now();
+
+    assertEquals(totp.remaining({ timestamp }), 30e3 - (timestamp % (30e3)));
+    assertEquals(OTPAuth.TOTP.remaining({ timestamp, period: 60 }), 60e3 - (timestamp % (60e3)));
+  });
+
   cases.forEach((input, index) => {
     it(`generate[${index}]`, () => {
       const totp = new OTPAuth.TOTP({


### PR DESCRIPTION
In my application using otpauth, I use the counter to prevent a TOTP code from being used twice during its validity period.

I'm proposing this PR so I don't have to duplicate this function in my code (and in the code of other developers who don't want TOTP code to be reused).